### PR TITLE
一处应当使用局部变量的地方使用了全局变量，可能对全局环境产生不必要的影响

### DIFF
--- a/Debugger/DebugTools.lua
+++ b/Debugger/DebugTools.lua
@@ -298,6 +298,7 @@ function this.createJson()
                 startPos = decode_scanWhitespace(s,startPos+1)
             end
             assert(startPos<=stringLen, 'JSON String ended unexpectedly scanning array.')
+            local object
             object, startPos = json.decode(s,startPos)
             array[index] = object
             index = index + 1


### PR DESCRIPTION
该闭包没有任何object的局部声明或上值，此处直接使用了全局变量