### PR TITLE
table分析不出多层嵌套数组的情况

### DIFF
--- a/src/code/server/docSymbolProcessor.ts
+++ b/src/code/server/docSymbolProcessor.ts
@@ -1440,8 +1440,10 @@ export class DocSymbolProcessor {
 
 				if (idxNode['type'] === 'TableValue') {
 					if (idxNode['value']['type'] === 'TableConstructorExpression') {
+						let recBaseName = baseInfo.name;
 						this.processTableConstructorExpression(idxNode['value'], type, deepLayer, prefix, baseInfo);
-					   if (this.posSearchRet && this.posSearchRet.isFindout) return;
+						if (this.posSearchRet && this.posSearchRet.isFindout) return;
+						baseInfo.name = recBaseName;
 				   }
 				}
 

--- a/src/code/server/docSymbolProcessor.ts
+++ b/src/code/server/docSymbolProcessor.ts
@@ -1438,6 +1438,13 @@ export class DocSymbolProcessor {
 					}
 				}
 
+				if (idxNode['type'] === 'TableValue') {
+					if (idxNode['value']['type'] === 'TableConstructorExpression') {
+						this.processTableConstructorExpression(idxNode['value'], type, deepLayer, prefix, baseInfo);
+					   if (this.posSearchRet && this.posSearchRet.isFindout) return;
+				   }
+				}
+
 			}
 
 			if (type === travelMode.FIND_REFS) {


### PR DESCRIPTION
```
local func_test = function()
	print("funcs")
end

local test = {}
test.adds = {
	tah = "snufsi",
	cdsi = 56,
	preloads = {
		{"Function", Func = function ( ... )
			func_test()
		end}	
	},
}
```
func_test跳转不了