### PR TITLE
fix Windows下配置luanch.json启动参数program时, 路径带有空格则启动失败. #152

### DIFF
--- a/src/debug/luaDebug.ts
+++ b/src/debug/luaDebug.ts
@@ -341,8 +341,12 @@ export class LuaDebugSession extends LoggingDebugSession {
                         name: "Run Program File (LuaPanda)",
                         env: {}, 
                     });
+
+                    let progaamCmdwithArgs = '"' + args.program + '"';
+                    if (os.type() === "Windows_NT") {
+                        progaamCmdwithArgs = '& ' + progaamCmdwithArgs;
+                    }
     
-                    let progaamCmdwithArgs = args.program;
                     for (const arg of args.args) {
                         progaamCmdwithArgs = progaamCmdwithArgs + " " + arg;
                     }


### PR DESCRIPTION
Solution:

- program自动加上双引号, 可兼容Windows, Linux
- 由于Windows下默认是powershell启动方式, 加上启动符 [& call operator](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_operators?view=powershell-7.1#call-operator-)

Tested:

- Linux & Windows均可支持带空格路径启动.
