### PR TITLE
bugfix:issue #150, 修复配置文件中后缀不包含分隔符时导致解析出来的文件名称为lua.lua的问题

### DIFF
--- a/Debugger/LuaPanda.lua
+++ b/Debugger/LuaPanda.lua
@@ -1699,6 +1699,11 @@ function this.changePotToSep(filePath, ext)
     local idx = filePath:find(ext, (-1) * ext:len() , true)
     if idx then 
         local tmp = filePath:sub(1, idx - 1):gsub("%.", "/");
+        -- 如果最后的后缀是/，代表luafileExtention不包含分隔符号，将其转换为.
+        if string.sub(tmp, -1) == "/" then
+            -- delete the last "/"
+            tmp = tmp:sub(1, -2) .. ".";
+        end
         filePath = tmp .. ext;
     end
     return filePath;


### PR DESCRIPTION
#150 issue修复
## 问题描述
当`luaFileExtension` 中不包含文件后缀的分隔符如`lua`时，会导致函数处理后缀时将`.`转换为`/`，将文件`test.lua`变成`test/lua`，进而解析出来的文件名称变成了`lua.lua`。
![image](https://github.com/Tencent/LuaPanda/assets/26404619/3e8f76f8-2c62-4eea-bf93-39bee61ec8f6)

## 解决方案
判断经过后缀处理之后的字符串是否以`/`结尾，如果是换成`.`结尾。